### PR TITLE
Removed numpy dependence

### DIFF
--- a/vptree.py
+++ b/vptree.py
@@ -1,5 +1,6 @@
 """ This module contains an implementation of a Vantage Point-tree (VP-tree)."""
-import numpy as np
+import math
+import statistics as stats
 
 
 class VPTree:
@@ -25,9 +26,9 @@ class VPTree:
     def __init__(self, points, dist_fn):
         self.left = None
         self.right = None
-        self.left_min = np.inf
+        self.left_min = math.inf
         self.left_max = 0
-        self.right_min = np.inf
+        self.right_min = math.inf
         self.right_max = 0
         self.dist_fn = dist_fn
 
@@ -35,16 +36,15 @@ class VPTree:
             raise ValueError('Points can not be empty.')
 
         # Vantage point is point furthest from parent vp.
-        vp_i = 0
-        self.vp = points[vp_i]
-        points = np.delete(points, vp_i, axis=0)
+        self.vp = points[0]
+        points = points[1:]
 
         if len(points) == 0:
             return
 
         # Choose division boundary at median of distances.
         distances = [self.dist_fn(self.vp, p) for p in points]
-        median = np.median(distances)
+        median = stats.median(distances)
 
         left_points = []
         right_points = []
@@ -75,7 +75,7 @@ class VPTree:
 
     def get_nearest_neighbor(self, query):
         """ Get single nearest neighbor.
-        
+
         Parameters
         ----------
         query : Any
@@ -90,7 +90,7 @@ class VPTree:
 
     def get_n_nearest_neighbors(self, query, n_neighbors):
         """ Get `n_neighbors` nearest neigbors to `query`
-        
+
         Parameters
         ----------
         query : Any
@@ -108,7 +108,7 @@ class VPTree:
         neighbors = _AutoSortingList(max_size=n_neighbors)
         nodes_to_visit = [(self, 0)]
 
-        furthest_d = np.inf
+        furthest_d = math.inf
 
         while len(nodes_to_visit) > 0:
             node, d0 = nodes_to_visit.pop(0)


### PR DESCRIPTION
Testing this library using 64,000 points and benchmarking the results seemed to suggest a lot of time was lost inside numpy. Moreover from what I could tell all of the numpy functions used had sensible replacements using python3 built in libraries. Thus I replaced the numpy references with those built-ins and found a noticeable speed gain.

I don't do a lot of performance benchmarking so apologies if the test was overly simplistic and I'm missing some case where numpy results in a speedup. 

For reference the "benchmark" I ran was:
```python
import vptree
from random import randint
import itertools
import cProfile

def random_points():
    while True:
        yield randint(-9000,9000), randint(-9000,9000)

def distance(x,y):
    return abs(x[0]-y[0]) + abs(x[1]-y[1])

if __name__ == "__main__":
    points = list(itertools.islice(random_points(),64000))
    pr = cProfile.Profile()
    pr.enable()
    tree = vptree.VPTree(points,distance)
    pr.disable()
    tree.get_n_nearest_neighbors((0,0), 7)
    pr.print_stats(sort="time")
```
Then the (truncated) outputs were as follows.
The numpy implementation:
```
         6565799 function calls (6501800 primitive calls) in 6.803 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  64000/1    2.548    0.000    6.803    6.803 vptree.py:25(__init__)
   894888    0.726    0.000    0.854    0.000 performance.py:10(distance)
    64000    0.627    0.000    1.212    0.000 function_base.py:4065(delete)
   260564    0.590    0.000    0.590    0.000 {built-in method numpy.core.multiarray.array}
   894888    0.358    0.000    0.358    0.000 {built-in method builtins.min}
    33141    0.340    0.000    1.194    0.000 vptree.py:46(<listcomp>)
    33141    0.192    0.000    1.137    0.000 function_base.py:3342(_median)
    33141    0.188    0.000    0.188    0.000 {method 'reduce' of 'numpy.ufunc' objects}
    33141    0.154    0.000    0.437    0.000 _methods.py:58(_mean)
```
Removing the numpy references:
```
         4864913 function calls (4800914 primitive calls) in 1.672 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  64000/1    0.639    0.000    1.672    1.672 vptree.py:26(__init__)
   894854    0.365    0.000    0.473    0.000 performance.py:10(distance)
    33107    0.202    0.000    0.675    0.000 vptree.py:46(<listcomp>)
   894854    0.164    0.000    0.164    0.000 {built-in method builtins.min}
  1789708    0.108    0.000    0.108    0.000 {built-in method builtins.abs}
    33107    0.091    0.000    0.091    0.000 {built-in method builtins.sorted}
   778889    0.047    0.000    0.047    0.000 {method 'append' of 'list' objects}
    33107    0.022    0.000    0.116    0.000 statistics.py:363(median)
   115965    0.017    0.000    0.017    0.000 {method 'insert' of 'list' objects}
   227321    0.016    0.000    0.016    0.000 {built-in method builtins.len}
```
Also, for what it's worth, the test file passed with the changes implement.