### PR TITLE
Use the distance as sort key explicitly.

### DIFF
--- a/vptree.py
+++ b/vptree.py
@@ -216,7 +216,7 @@ class _AutoSortingList(list):
             Input item.
         """
         super(_AutoSortingList, self).append(item)
-        self.sort()
+        self.sort(key=lambda x: x[0])
         if self.max_size is not None and len(self) > self.max_size:
             self.pop()
 


### PR DESCRIPTION
Without the explicit sort key I encountered a ValueError when using numpy arrays as values:
"ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()."

You may want to change the code further to make the sort key configurable.

(Using Python 3.6.8 and numpy 1.17.3)